### PR TITLE
Variablized `date` command for use on MacOS and general clean up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can set some configuration variables to customize the script:
 * `exclusionFileName`: Name given to the text file that contains exclusion patterns. You must create it inside directory defined by `ownFolderName`.
 * `ownFolderName`: Name given to folder inside user's home to hold configuration files and logs while backup is in progress.
 * `logFolderName`: Directory inside `dst` where the log files are stored.
+* `dateCmd`: Command to run for GNU `date`
 
 All files and folders in backup (local and remote only) get read permissions for all users, since a non-readable backup is useless.
 If you are worried about permissions, you can add a security layer on backup access level (FTP accounts protected with passwords, for example).

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -10,9 +10,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
-logName="rsync-incremental-backup_$(date -Id)_$(date +%H-%M-%S).log"
+logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
+dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"
@@ -46,20 +47,20 @@ do
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(date -Is)] You are going to backup"
+writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
 writeToLog "\tfrom:  ${src}"
 writeToLog "\tto:    ${bak0}"
 
 # Prepare paths at destination
 mkdir -p "${dst}" "${logPath}"
 
-writeToLog "\n[$(date -Is)] Old logs sending begins\n"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
 
 # Send old pending logs to destination
 rsync -rhv --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${logPath}/"
 
-writeToLog "\n[$(date -Is)] Old logs sending finished"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if ([ ! -e "${rotationLockFilePath}" ])
@@ -67,7 +68,7 @@ then
 	# .. and there is previous data
 	if [ -d "${bak0}" ]
 	then
-		writeToLog "\n[$(date -Is)] Backups rotation begins"
+		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -87,18 +88,18 @@ then
 			fi
 		done
 
-		writeToLog "[$(date -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
 	else
-		writeToLog "\n[$(date -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
 	fi
 else
-	writeToLog "\n[$(date -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 touch "${rotationLockFilePath}"
 
-writeToLog "[$(date -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
 
 # Do the backup
 rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
@@ -108,13 +109,13 @@ rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/"
 # Check rsync success
 if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(date -Is)] Backup completed successfully\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
 
 	# Clear unneeded partials and lock file
 	rm -rf "${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(date -Is)] Backup failed, try again later\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
 	rsyncFail=1
 fi
 

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -10,7 +10,7 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
-dateCmd="gdate"
+dateCmd="date"
 logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
@@ -43,7 +43,7 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
+	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
 	true "$((i = i + 1))"
 done
 

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -43,24 +43,24 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
+	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
-writeToLog "\tfrom:  ${src}"
-writeToLog "\tto:    ${bak0}"
+writeToLog "\\n[$(${dateCmd} -Is)] You are going to backup"
+writeToLog "\\tfrom:  ${src}"
+writeToLog "\\tto:    ${bak0}"
 
 # Prepare paths at destination
 mkdir -p "${dst}" "${logPath}"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending begins\\n"
 
 # Send old pending logs to destination
 rsync -rhv --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${logPath}/"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if ([ ! -e "${rotationLockFilePath}" ])
@@ -68,7 +68,7 @@ then
 	# .. and there is previous data
 	if [ -d "${bak0}" ]
 	then
-		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
+		writeToLog "\\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -88,34 +88,31 @@ then
 			fi
 		done
 
-		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\\n"
 	else
-		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\\n"
 	fi
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 touch "${rotationLockFilePath}"
 
-writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 
 # Do the backup
-rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
+if rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
 --log-file="${logFile}" --exclude="${ownFolderPath}" --chmod=+r \
 --exclude-from="${exclusionFilePath}" "${src}/" "${bak0}/"
-
-# Check rsync success
-if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 
 	# Clear unneeded partials and lock file
 	rm -rf "${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup failed, try again later\\n"
 	rsyncFail=1
 fi
 

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -10,10 +10,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
+dateCmd="gdate"
 logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
-dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -12,9 +12,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
-logName="rsync-incremental-backup_$(date -Id)_$(date +%H-%M-%S).log"
+logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
+dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"
@@ -52,7 +53,7 @@ do
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(date -Is)] You are going to backup"
+writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
 writeToLog "\tfrom:  ${src}"
 writeToLog "\tto:    ${remoteBak0}"
 
@@ -60,20 +61,20 @@ writeToLog "\tto:    ${remoteBak0}"
 ssh -q -o BatchMode=yes -o ConnectTimeout=10 "${remote}" exit
 if [ "${?}" -ne "0" ]
 then
-	writeToLog "\n[$(date -Is)] Remote destination is not reachable"
+	writeToLog "\n[$(${dateCmd} -Is)] Remote destination is not reachable"
 	exit 1
 fi
 
 # Prepare paths at destination
 ssh "${remote}" "mkdir -p ${dst} ${logPath}"
 
-writeToLog "\n[$(date -Is)] Old logs sending begins\n"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
 
 # Send old pending logs to destination
 rsync -rhvz --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${remoteLogPath}/"
 
-writeToLog "\n[$(date -Is)] Old logs sending finished"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if (ssh "${remote}" "[ ! -d ${partialFolderPath} ] && [ ! -e ${rotationLockFilePath} ]")
@@ -81,7 +82,7 @@ then
 	# .. and there is previous data
 	if (ssh "${remote}" "[ -d ${bak0} ]")
 	then
-		writeToLog "\n[$(date -Is)] Backups rotation begins"
+		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -101,18 +102,18 @@ then
 			fi
 		done
 
-		writeToLog "[$(date -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
 	else
-		writeToLog "\n[$(date -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
 	fi
 else
-	writeToLog "\n[$(date -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 ssh "${remote}" "touch ${rotationLockFilePath}"
 
-writeToLog "[$(date -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
 
 # Do the backup
 rsync -achvz --progress --timeout="${timeout}" --delete --no-W --partial-dir="${partialFolderName}" \
@@ -122,13 +123,13 @@ rsync -achvz --progress --timeout="${timeout}" --delete --no-W --partial-dir="${
 # Check rsync success
 if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(date -Is)] Backup completed successfully\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
 
 	# Clear unneeded partials and lock file
 	ssh "${remote}" "rm -rf ${partialFolderPath} ${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(date -Is)] Backup failed, try again later\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
 	rsyncFail=1
 fi
 

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2029
 
 # Configuration variables (change as you wish)
 src="${1:-/path/to/source}"
@@ -13,7 +12,7 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
-dateCmd="gdate"
+dateCmd="date"
 logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
@@ -50,7 +49,7 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
+	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
 	true "$((i = i + 1))"
 done
 

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2029
 
 # Configuration variables (change as you wish)
 src="${1:-/path/to/source}"
@@ -49,32 +50,31 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
+	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
-writeToLog "\tfrom:  ${src}"
-writeToLog "\tto:    ${remoteBak0}"
+writeToLog "\\n[$(${dateCmd} -Is)] You are going to backup"
+writeToLog "\\tfrom:  ${src}"
+writeToLog "\\tto:    ${remoteBak0}"
 
 # Check remote connection
-ssh -q -o BatchMode=yes -o ConnectTimeout=10 "${remote}" exit
-if [ "${?}" -ne "0" ]
+if ssh -q -o BatchMode=yes -o ConnectTimeout=10 "${remote}" exit
 then
-	writeToLog "\n[$(${dateCmd} -Is)] Remote destination is not reachable"
+	writeToLog "\\n[$(${dateCmd} -Is)] Remote destination is not reachable"
 	exit 1
 fi
 
 # Prepare paths at destination
 ssh "${remote}" "mkdir -p ${dst} ${logPath}"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending begins\\n"
 
 # Send old pending logs to destination
 rsync -rhvz --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${remoteLogPath}/"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if (ssh "${remote}" "[ ! -d ${partialFolderPath} ] && [ ! -e ${rotationLockFilePath} ]")
@@ -82,7 +82,7 @@ then
 	# .. and there is previous data
 	if (ssh "${remote}" "[ -d ${bak0} ]")
 	then
-		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
+		writeToLog "\\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -102,40 +102,37 @@ then
 			fi
 		done
 
-		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\\n"
 	else
-		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\\n"
 	fi
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 ssh "${remote}" "touch ${rotationLockFilePath}"
 
-writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 
 # Do the backup
-rsync -achvz --progress --timeout="${timeout}" --delete --no-W --partial-dir="${partialFolderName}" \
+if rsync -achvz --progress --timeout="${timeout}" --delete --no-W --partial-dir="${partialFolderName}" \
 --link-dest="${bak1}/" --log-file="${logFile}" --exclude="${ownFolderPath}" --chmod=+r \
 --exclude-from="${exclusionFilePath}" "${src}/" "${remoteBak0}/"
 
-# Check rsync success
-if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 
 	# Clear unneeded partials and lock file
 	ssh "${remote}" "rm -rf ${partialFolderPath} ${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup failed, try again later\\n"
 	rsyncFail=1
 fi
 
 # Send the complete log file to destination
-scp "${logFile}" "${remoteLogPath}"
-if [ "${?}" -eq "0" ]
+if scp "${logFile}" "${remoteLogPath}"
 then
 	rm "${logFile}"
 fi

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -13,10 +13,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
+dateCmd="gdate"
 logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
-dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"

--- a/rsync-incremental-backup-system
+++ b/rsync-incremental-backup-system
@@ -10,9 +10,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
-logName="rsync-incremental-backup_$(date -Id)_$(date +%H-%M-%S).log"
+logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
+dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"
@@ -46,20 +47,20 @@ do
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(date -Is)] You are going to backup"
+writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
 writeToLog "\tfrom:  ${src}"
 writeToLog "\tto:    ${bak0}"
 
 # Prepare paths at destination
 mkdir -p "${dst}" "${logPath}"
 
-writeToLog "\n[$(date -Is)] Old logs sending begins\n"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
 
 # Send old pending logs to destination
 rsync -rhv --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${logPath}/"
 
-writeToLog "\n[$(date -Is)] Old logs sending finished"
+writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if ([ ! -e "${rotationLockFilePath}" ])
@@ -67,7 +68,7 @@ then
 	# .. and there is previous data
 	if [ -d "${bak0}" ]
 	then
-		writeToLog "\n[$(date -Is)] Backups rotation begins"
+		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -87,18 +88,18 @@ then
 			fi
 		done
 
-		writeToLog "[$(date -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
 	else
-		writeToLog "\n[$(date -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
 	fi
 else
-	writeToLog "\n[$(date -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 touch "${rotationLockFilePath}"
 
-writeToLog "[$(date -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
 
 # Do the backup (with mandatory exclusions)
 rsync -aAXhv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
@@ -109,13 +110,13 @@ rsync -aAXhv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/
 # Check rsync success
 if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(date -Is)] Backup completed successfully\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
 
 	# Clear unneeded partials and lock file
 	rm -rf "${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(date -Is)] Backup failed, try again later\n"
+	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
 	rsyncFail=1
 fi
 

--- a/rsync-incremental-backup-system
+++ b/rsync-incremental-backup-system
@@ -10,10 +10,10 @@ rotationLockFileName=".rsync-rotation-lock"
 pathBakN="backup"
 nameBakN="backup"
 exclusionFileName="exclude.txt"
+dateCmd="date"
 logName="rsync-incremental-backup_$(${dateCmd} -Id)_$(${dateCmd} +%H-%M-%S).log"
 ownFolderName=".rsync-incremental-backup"
 logFolderName="log"
-dateCmd="date"
 
 # Combinate previously defined variables for use (don't touch this)
 ownFolderPath="${HOME}/${ownFolderName}"

--- a/rsync-incremental-backup-system
+++ b/rsync-incremental-backup-system
@@ -43,7 +43,7 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
+	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
 	true "$((i = i + 1))"
 done
 

--- a/rsync-incremental-backup-system
+++ b/rsync-incremental-backup-system
@@ -43,24 +43,24 @@ writeToLog "********************************"
 i=1
 while [ "${i}" -le "${backupDepth}" ]
 do
-	export "bak${i}"="${dst}/${pathBakN}/${nameBakN}.${i}"
+	export bak"${i}"="${dst}"/"${pathBakN}"/"${nameBakN}"."${i}"
 	true "$((i = i + 1))"
 done
 
-writeToLog "\n[$(${dateCmd} -Is)] You are going to backup"
-writeToLog "\tfrom:  ${src}"
-writeToLog "\tto:    ${bak0}"
+writeToLog "\\n[$(${dateCmd} -Is)] You are going to backup"
+writeToLog "\\tfrom:  ${src}"
+writeToLog "\\tto:    ${bak0}"
 
 # Prepare paths at destination
 mkdir -p "${dst}" "${logPath}"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending begins\n"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending begins\\n"
 
 # Send old pending logs to destination
 rsync -rhv --remove-source-files --exclude="${logName}" --log-file="${logFile}" \
 "${tempLogPath}/" "${logPath}/"
 
-writeToLog "\n[$(${dateCmd} -Is)] Old logs sending finished"
+writeToLog "\\n[$(${dateCmd} -Is)] Old logs sending finished"
 
 # Rotate backups if last rsync succeeded ..
 if ([ ! -e "${rotationLockFilePath}" ])
@@ -68,7 +68,7 @@ then
 	# .. and there is previous data
 	if [ -d "${bak0}" ]
 	then
-		writeToLog "\n[$(${dateCmd} -Is)] Backups rotation begins"
+		writeToLog "\\n[$(${dateCmd} -Is)] Backups rotation begins"
 
 		true "$((i = i - 1))"
 
@@ -88,35 +88,33 @@ then
 			fi
 		done
 
-		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\n"
+		writeToLog "[$(${dateCmd} -Is)] Backups rotation finished\\n"
 	else
-		writeToLog "\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\n"
+		writeToLog "\\n[$(${dateCmd} -Is)] No previous data found, there is no backups to be rotated\\n"
 	fi
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Last backup failed, backups will not be rotated\\n"
 fi
 
 # Set rotation lock file to detect in next run when backup fails
 touch "${rotationLockFilePath}"
 
-writeToLog "[$(${dateCmd} -Is)] Backup begins\n"
+writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 
 # Do the backup (with mandatory exclusions)
-rsync -aAXhv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
+if rsync -aAXhv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
 --log-file="${logFile}" --exclude="${ownFolderPath}" --exclude-from="${exclusionFilePath}" \
 --exclude={"/dev/*","/proc/*","/sys/*","/tmp/*","/run/*","/mnt/*","/media/*","/lost+found"} \
 "${src}/" "${bak0}/"
 
-# Check rsync success
-if [ "${?}" -eq "0" ]
 then
-	writeToLog "\n[$(${dateCmd} -Is)] Backup completed successfully\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 
 	# Clear unneeded partials and lock file
 	rm -rf "${rotationLockFilePath}"
 	rsyncFail=0
 else
-	writeToLog "\n[$(${dateCmd} -Is)] Backup failed, try again later\n"
+	writeToLog "\\n[$(${dateCmd} -Is)] Backup failed, try again later\\n"
 	rsyncFail=1
 fi
 


### PR DESCRIPTION
Just grabbed this script to do a local incremental rsync backup, but had issues since I needed to use `gdate` on the Mac.  After that in a second commit I added some clean up suggested by [shellcheck](https://github.com/koalaman/shellcheck).  

Just noticed that I need to move the definition of `dateCmd` so now there are three commit.
I tested both the local and remote scripts and all went well, I did not test the system script but is so similar to the local script it should be ok.  

Not sure it would be useful to others just putting it out there.