### PR TITLE
Enable --include-from flag of rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can set some configuration variables to customize the script:
 * `nameBakN`: Name of incremental backup directories. An index will be added at the end to show how old they are.
 * `logName`: Name given to log file generated at backup.
 * `exclusionFileName`: Name given to the text file that contains exclusion patterns. You must create it inside directory defined by `ownFolderName`.
-* `source_fileFileName`: Name given to the text file that contains list of source-file names. You must create it inside directory defined by `ownFolderName`.
+* `inclusionFileName`: Name given to the text file that contains inclusion patterns. You must create it inside directory defined by `ownFolderName`.
 * `ownFolderName`: Name given to folder inside user's home to hold configuration files and logs while backup is in progress.
 * `logFolderName`: Directory inside `dst` where the log files are stored.
 * `dateCmd`: Command to run for GNU `date`
@@ -143,7 +143,7 @@ Log files per backup operation will be stored at `<dst>/log`.
 * `--chmod`: affect file and/or directory permissions.
 * `--exclude`: exclude files matching pattern.
 * `--exclude-from`: same as `--exclude`, but getting patterns from specified file.
-* `--files-from`: read list of source-file names from `source_fileFileName`
+* `--include-from`: get patterns from specified file.
 
 * Used only for remote backup:
 	* `--no-W`: ensures that rsync's delta-transfer algorithm is used, so it never transfers whole files if they are present at target. Omit only when you have a high bandwidth to target, backup may be faster.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can set some configuration variables to customize the script:
 * `nameBakN`: Name of incremental backup directories. An index will be added at the end to show how old they are.
 * `logName`: Name given to log file generated at backup.
 * `exclusionFileName`: Name given to the text file that contains exclusion patterns. You must create it inside directory defined by `ownFolderName`.
+* `source_fileFileName`: Name given to the text file that contains list of source-file names. You must create it inside directory defined by `ownFolderName`.
 * `ownFolderName`: Name given to folder inside user's home to hold configuration files and logs while backup is in progress.
 * `logFolderName`: Directory inside `dst` where the log files are stored.
 * `dateCmd`: Command to run for GNU `date`
@@ -142,6 +143,7 @@ Log files per backup operation will be stored at `<dst>/log`.
 * `--chmod`: affect file and/or directory permissions.
 * `--exclude`: exclude files matching pattern.
 * `--exclude-from`: same as `--exclude`, but getting patterns from specified file.
+* `--files-from`: read list of source-file names from `source_fileFileName`
 
 * Used only for remote backup:
 	* `--no-W`: ensures that rsync's delta-transfer algorithm is used, so it never transfers whole files if they are present at target. Omit only when you have a high bandwidth to target, backup may be faster.

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -10,7 +10,7 @@ rotationLockFileName="${rotationLockFileName:-.rsync-rotation-lock}"
 pathBakN="${pathBakN:-backup}"
 nameBakN="${nameBakN:-backup}"
 exclusionFileName="${exclusionFileName:-exclude.txt}"
-source_fileFileName="${source_fileFileName:-source_file.txt}"
+inclusionFileName="${inclusionFileName:-include.txt}"
 dateCmd="${dateCmd:-date}"
 logName="${logName:-rsync-incremental-backup_$(${dateCmd} +%Y-%m-%d)_$(${dateCmd} +%H-%M-%S).log}"
 ownFolderName="${ownFolderName:-.rsync-incremental-backup}"
@@ -20,7 +20,7 @@ logFolderName="${logFolderName:-log}"
 ownFolderPath="${HOME}/${ownFolderName}"
 tempLogPath="${ownFolderPath}/local_${dst//[\/]/\\}"
 exclusionFilePath="${ownFolderPath}/${exclusionFileName}"
-source_fileFilePath="${ownFolderPath}/${source_fileFileName}"
+inclusionFilePath="${ownFolderPath}/${inclusionFileName}"
 bak0="${dst}/${pathBak0}"
 rotationLockFilePath="${dst}/${rotationLockFileName}"
 logPath="${dst}/${pathBakN}/${logFolderName}"
@@ -30,7 +30,7 @@ logFile="${tempLogPath}/${logName}"
 mkdir -p "${tempLogPath}"
 touch "${logFile}"
 touch "${exclusionFilePath}"
-touch "${source_fileFilePath}"
+touch "${inclusionFilePath}"
 
 writeToLog() {
 	echo -e "${1}" | tee -a "${logFile}"
@@ -107,7 +107,7 @@ writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 # Do the backup
 if rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
 	--log-file="${logFile}" --exclude="${ownFolderPath}" --chmod=+r \
-	--exclude-from="${exclusionFilePath}" --files-from="${source_fileFilePath}" "${src}/" "${bak0}/"
+	--exclude-from="${exclusionFilePath}" --include-from="${inclusionFilePath}" "${src}/" "${bak0}/"
 then
 	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 

--- a/rsync-incremental-backup-local
+++ b/rsync-incremental-backup-local
@@ -10,6 +10,7 @@ rotationLockFileName="${rotationLockFileName:-.rsync-rotation-lock}"
 pathBakN="${pathBakN:-backup}"
 nameBakN="${nameBakN:-backup}"
 exclusionFileName="${exclusionFileName:-exclude.txt}"
+source_fileFileName="${source_fileFileName:-source_file.txt}"
 dateCmd="${dateCmd:-date}"
 logName="${logName:-rsync-incremental-backup_$(${dateCmd} +%Y-%m-%d)_$(${dateCmd} +%H-%M-%S).log}"
 ownFolderName="${ownFolderName:-.rsync-incremental-backup}"
@@ -19,6 +20,7 @@ logFolderName="${logFolderName:-log}"
 ownFolderPath="${HOME}/${ownFolderName}"
 tempLogPath="${ownFolderPath}/local_${dst//[\/]/\\}"
 exclusionFilePath="${ownFolderPath}/${exclusionFileName}"
+source_fileFilePath="${ownFolderPath}/${source_fileFileName}"
 bak0="${dst}/${pathBak0}"
 rotationLockFilePath="${dst}/${rotationLockFileName}"
 logPath="${dst}/${pathBakN}/${logFolderName}"
@@ -28,6 +30,7 @@ logFile="${tempLogPath}/${logName}"
 mkdir -p "${tempLogPath}"
 touch "${logFile}"
 touch "${exclusionFilePath}"
+touch "${source_fileFilePath}"
 
 writeToLog() {
 	echo -e "${1}" | tee -a "${logFile}"
@@ -104,7 +107,7 @@ writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 # Do the backup
 if rsync -achv --progress --timeout="${timeout}" --delete -W --link-dest="${bak1}/" \
 	--log-file="${logFile}" --exclude="${ownFolderPath}" --chmod=+r \
-	--exclude-from="${exclusionFilePath}" "${src}/" "${bak0}/"
+	--exclude-from="${exclusionFilePath}" --files-from="${source_fileFilePath}" "${src}/" "${bak0}/"
 then
 	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -12,7 +12,7 @@ rotationLockFileName="${rotationLockFileName:-.rsync-rotation-lock}"
 pathBakN="${pathBakN:-backup}"
 nameBakN="${nameBakN:-backup}"
 exclusionFileName="${exclusionFileName:-exclude.txt}"
-source_fileFileName="${source_fileFileName:-source_file.txt}"
+inclusionFileName="${inclusionFileName:-include.txt}"
 dateCmd="${dateCmd:-date}"
 logName="${logName:-rsync-incremental-backup_$(${dateCmd} +%Y-%m-%d)_$(${dateCmd} +%H-%M-%S).log}"
 ownFolderName="${ownFolderName:-.rsync-incremental-backup}"
@@ -23,7 +23,7 @@ interactiveMode="${interactiveMode:-no}"
 ownFolderPath="${HOME}/${ownFolderName}"
 tempLogPath="${ownFolderPath}/${remote}_${dst//[\/]/\\}"
 exclusionFilePath="${ownFolderPath}/${exclusionFileName}"
-source_fileFilePath="${ownFolderPath}/${source_fileFileName}"
+inclusionFilePath="${ownFolderPath}/${inclusionFileName}"
 remoteDst="${remote}:${dst}"
 bak0="${dst}/${pathBak0}"
 remoteBak0="${remoteDst}/${pathBak0}"
@@ -37,7 +37,7 @@ logFile="${tempLogPath}/${logName}"
 mkdir -p "${tempLogPath}"
 touch "${logFile}"
 touch "${exclusionFilePath}"
-touch "${source_fileFilePath}"
+touch "${inclusionFilePath}"
 
 writeToLog() {
 	echo -e "${1}" | tee -a "${logFile}"
@@ -134,7 +134,7 @@ writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 # Do the backup
 if rsync "${rsyncShellParams[@]}" -achvz --progress --timeout="${timeout}" --delete --no-W \
 	--partial-dir="${partialFolderName}" --link-dest="${bak1}/" --log-file="${logFile}" --exclude="${ownFolderPath}" \
-	--chmod=+r --exclude-from="${exclusionFilePath}" --files-from="${source_fileFilePath}" "${src}/" "${remoteBak0}/"
+	--chmod=+r --exclude-from="${exclusionFilePath}" --include-from="${inclusionFilePath}" "${src}/" "${remoteBak0}/"
 then
 	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 

--- a/rsync-incremental-backup-remote
+++ b/rsync-incremental-backup-remote
@@ -12,6 +12,7 @@ rotationLockFileName="${rotationLockFileName:-.rsync-rotation-lock}"
 pathBakN="${pathBakN:-backup}"
 nameBakN="${nameBakN:-backup}"
 exclusionFileName="${exclusionFileName:-exclude.txt}"
+source_fileFileName="${source_fileFileName:-source_file.txt}"
 dateCmd="${dateCmd:-date}"
 logName="${logName:-rsync-incremental-backup_$(${dateCmd} +%Y-%m-%d)_$(${dateCmd} +%H-%M-%S).log}"
 ownFolderName="${ownFolderName:-.rsync-incremental-backup}"
@@ -22,6 +23,7 @@ interactiveMode="${interactiveMode:-no}"
 ownFolderPath="${HOME}/${ownFolderName}"
 tempLogPath="${ownFolderPath}/${remote}_${dst//[\/]/\\}"
 exclusionFilePath="${ownFolderPath}/${exclusionFileName}"
+source_fileFilePath="${ownFolderPath}/${source_fileFileName}"
 remoteDst="${remote}:${dst}"
 bak0="${dst}/${pathBak0}"
 remoteBak0="${remoteDst}/${pathBak0}"
@@ -35,6 +37,7 @@ logFile="${tempLogPath}/${logName}"
 mkdir -p "${tempLogPath}"
 touch "${logFile}"
 touch "${exclusionFilePath}"
+touch "${source_fileFilePath}"
 
 writeToLog() {
 	echo -e "${1}" | tee -a "${logFile}"
@@ -131,7 +134,7 @@ writeToLog "[$(${dateCmd} -Is)] Backup begins\\n"
 # Do the backup
 if rsync "${rsyncShellParams[@]}" -achvz --progress --timeout="${timeout}" --delete --no-W \
 	--partial-dir="${partialFolderName}" --link-dest="${bak1}/" --log-file="${logFile}" --exclude="${ownFolderPath}" \
-	--chmod=+r --exclude-from="${exclusionFilePath}" "${src}/" "${remoteBak0}/"
+	--chmod=+r --exclude-from="${exclusionFilePath}" --files-from="${source_fileFilePath}" "${src}/" "${remoteBak0}/"
 then
 	writeToLog "\\n[$(${dateCmd} -Is)] Backup completed successfully\\n"
 


### PR DESCRIPTION
I add the --include-from so that `rsync` can include specified pattern.
I originally use --files-from but it can not be backward compatible.

Thanks.